### PR TITLE
fix: ub caused by function_ref

### DIFF
--- a/SpindlePass/visitor.h
+++ b/SpindlePass/visitor.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <set>
+#include <functional>
 
 #include "AST.h"
 #include "MAS.h"
@@ -10,13 +11,14 @@
 using namespace llvm;
 using std::map;
 using std::set;
+using std::function;
 
 class ASTVisitor : public InstVisitor<ASTVisitor, ASTAbstractNode *> {
-    function_ref<bool(Value *)> leafChecker;
+    function<bool(Value *)> leafChecker;
     bool debug;
 
 public:
-    explicit ASTVisitor(function_ref<bool(Value *)> leafComputableChecker,
+    explicit ASTVisitor(function<bool(Value *)> leafComputableChecker,
                         bool debug = false)
         : leafChecker(leafComputableChecker), debug(debug) {
     }


### PR DESCRIPTION
https://github.com/thu-pacman/Spindle/blob/dcb157a960f915f031686d2570501b381f001608/SpindlePass/STracer.cpp#L79-L85

These `ASTVisitor`s are initialized with non-owning `llvm::function_ref`, causing undefined behavior as the lambdas may not live long enough to be properly called.